### PR TITLE
+ add connection timeout error handling

### DIFF
--- a/lib/himmel/weather.ex
+++ b/lib/himmel/weather.ex
@@ -31,13 +31,18 @@ defmodule Himmel.Weather do
   def handle_call({:get, %Place{location_id: location_id} = place}, _from, state) do
     case Map.get(state, location_id) do
       nil ->
-        place_with_updated_weather = Services.Weather.get_weather(place)
-        new_state = Map.put(state, location_id, place_with_updated_weather)
+        case Services.Weather.get_weather(place) do
+          {:ok, weather} ->
+            new_state = Map.put(state, location_id, weather)
+            {:reply, {:ok, weather}, new_state}
 
-        {:reply, place_with_updated_weather, new_state}
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
+        end
 
-      place_with_weather ->
-        {:reply, place_with_weather, state}
+      cached_weather ->
+        # {:reply, {:error, :timeout}, state}
+        {:reply, {:ok, cached_weather}, state}
     end
   end
 

--- a/lib/himmel_web/components/error.ex
+++ b/lib/himmel_web/components/error.ex
@@ -1,0 +1,16 @@
+defmodule HimmelWeb.Components.ApplicationError do
+  use HimmelWeb, :component
+
+  def application_error(assigns) do
+    ~H"""
+    <%!-- <div class={"#{if @screen == :error, do: "flex", else: "hidden md:flex"} flex-col gap-3 w-full md:max-w-[400px] lg:min-w-[450px] xl:max-w-[450px] 2xl:max-w=[520px]"}> --%>
+    <div class="pt-40 flex-col gap-3 text-center w-full md:max-w-[400px] lg:min-w-[450px] xl:max-w-[450px] 2xl:max-w=[520px]">
+      <h2 class="text-white text-5xl font-bold">Sorry!</h2>
+      <div class="text-white font-light text-3xl pt-12 flex flex-col gap-6">
+        <p><%= @error.reason %></p>
+        <p><%= @error.advisory %></p>
+      </div>
+    </div>
+    """
+  end
+end


### PR DESCRIPTION
This branch handles connection timeout errors from Finch or Mint, by passing along either: `{:ok, data}` or `{:error, :timeout}`. A new `init_data_start(socket)` function is called within the app's mount function. This first tests the connection by requesting the current location's weather.

If the response is `{:error, :timeout}`, the socket is assigned a `screen` value of `:error`, and an `error` value of a map with a text reason and advisory. This is used in a new `application_error` function component that's shown when there's an error.

Otherwise, the application functions as before.

Note: only timeout-related errors have so far been handled. Other errors could still arise which may cause the application to crash